### PR TITLE
fix: auth client has to be reset after signout

### DIFF
--- a/providers/ic/src/providers/auth/auth.providers.ts
+++ b/providers/ic/src/providers/auth/auth.providers.ts
@@ -102,6 +102,9 @@ export const signOut: SignOut = async (): Promise<void> => {
 
   await authClient?.logout();
 
+  // Reset local object otherwise next sign in (sign in - sign out - sign in) might not work out - i.e. agent-js might not recreate the delegation or identity if not resetted
+  authClient = undefined;
+
   // Just in case the user has been wrongly saved locally - this can be deleted in a bit
   await del('/user');
 };


### PR DESCRIPTION
If auth client (agent-js) is not reset after sign out then there might be issue on next sign in if still in memory