### PR TITLE
feat: preserve chunks order

### DIFF
--- a/providers/ic/src/api/storage.api.ts
+++ b/providers/ic/src/api/storage.api.ts
@@ -43,9 +43,9 @@ export const upload = async ({
   const t1 = performance.now();
   log({msg: `[upload][create batch] ${filename}`, duration: t1 - t0, level: 'info'});
 
-  const promises = [];
-
   const chunkSize = 700000;
+
+  const chunkIds: {chunk_id: bigint}[] = [];
 
   // Prevent transforming chunk to arrayBuffer error: The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.
   const clone: Blob = new Blob([await data.arrayBuffer()]);
@@ -53,16 +53,14 @@ export const upload = async ({
   for (let start = 0; start < clone.size; start += chunkSize) {
     const chunk: Blob = clone.slice(start, start + chunkSize);
 
-    promises.push(
-      uploadChunk({
+    chunkIds.push(
+      await uploadChunk({
         batchId,
         chunk,
         storageActor
       })
     );
   }
-
-  const chunkIds: {chunk_id: bigint}[] = await Promise.all(promises);
 
   const t2 = performance.now();
   log({msg: `[upload][chunks] ${filename}`, duration: t2 - t1, level: 'info'});

--- a/scripts/ic.install-storage.mjs
+++ b/scripts/ic.install-storage.mjs
@@ -10,8 +10,6 @@ const installWasm = async ({actor, type, wasmModule}) => {
 
   const chunkSize = 700000;
 
-  const promises = [];
-
   const upload = async (chunks) => {
     const result = await actor.storageLoadWasm(chunks);
     console.log('Chunks:', result);
@@ -19,10 +17,8 @@ const installWasm = async ({actor, type, wasmModule}) => {
 
   for (let start = 0; start < wasmModule.length; start += chunkSize) {
     const chunks = wasmModule.slice(start, start + chunkSize);
-    promises.push(upload(chunks));
+    await upload(chunks);
   }
-
-  await Promise.all(promises);
 
   console.log(`Installation ${type} done.`);
 };


### PR DESCRIPTION
There isn't such an issue in prod but just to be sure, as it can happens  in the NodeJS script, upload the chunks one after the other